### PR TITLE
Add the ability to disable highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Highlight words and lines on the cursor for Neovim
 ## Installation
 Install with your favorite plugin manager.
 
+## Highlighting
+You can override cursor highlighting by defining `CursorWord` group and disabling built-in highlighting by specifying `vim.g.cursorword_highlight` (lua) or `g:cursorword_highlight` (vimscript).
+
 ## Acknowledgments
 Thanks goes to these people/projects for inspiration:
 

--- a/lua/nvim-cursorline.lua
+++ b/lua/nvim-cursorline.lua
@@ -17,7 +17,9 @@ local normal_bg = return_highlight_term("Normal", "guibg")
 local cursorline_bg = return_highlight_term("CursorLine", "guibg")
 
 function M.highlight_cursorword()
-  vim.cmd("highlight CursorWord term=underline cterm=underline gui=underline")
+  if vim.g.cursorword_highlight ~= false then
+    vim.cmd('highlight CursorWord term=underline cterm=underline gui=underline')
+  end
 end
 
 function M.matchadd()


### PR DESCRIPTION
Closes #2. This will allow to do the following in user configuration (lua):

```lua
vim.g.cursorword_highlight = false

vim.cmd('highlight link CursorWord Pmenu')
```