### PR TITLE
fix: error when not have hl group name of Normal

### DIFF
--- a/lua/nvim-cursorline.lua
+++ b/lua/nvim-cursorline.lua
@@ -45,6 +45,9 @@ function M.cursor_moved()
 	M.timer_start()
 	if status == cursor then
 		-- vim.wo.cursorline = false
+    if normal_bg == '' then
+      normal_bg='NONE'
+    end
 		vim.cmd('highlight! CursorLine guibg=' .. normal_bg)
 		vim.cmd('highlight! CursorLineNr guibg=' .. normal_bg)
 		status = disabled


### PR DESCRIPTION
Hey, I found an error about me if no colorscheme was loaded. If I loaded colorscheme neovim will prompt me that "E5108: Error executing lua ...ack/packer/start/nvim-cursorline/lua/nvim-cursorline.lua:48: Vim(highlight)" because `guibg` missing parameters.