### PR TITLE
feat: configurable cursorline timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Install with your favorite plugin manager.
 ## Highlighting
 You can override cursor highlighting by defining `CursorWord` group and disabling built-in highlighting by specifying `vim.g.cursorword_highlight` (lua) or `g:cursorword_highlight` (vimscript).
 
+To lower the time it takes to make the cursorline appear, set `vim.g.cursorword_cursorline_timeout` (lua) or `g:cursorword_cursorline_timeout` (vimscript), where `1000` is the default value in milliseconds.
+
 ## Acknowledgments
 Thanks goes to these people/projects for inspiration:
 

--- a/lua/nvim-cursorline.lua
+++ b/lua/nvim-cursorline.lua
@@ -6,6 +6,8 @@ local window = 2
 local status = cursor
 local timer = vim.loop.new_timer()
 
+local cursorline_timeout = vim.g.cursorword_cursorline_timeout and vim.g.cursorword_cursorline_timeout or 1000
+
 vim.wo.cursorline = true
 
 local function return_highlight_term(group, term)
@@ -74,7 +76,7 @@ end
 
 function M.timer_start()
   timer:start(
-    1000,
+    cursorline_timeout,
     0,
     vim.schedule_wrap(
       function()


### PR DESCRIPTION
Since this plugin does not rely on the `updatetime` setting in vim then I assume it's safe to change this value without much of an performance impact.

I like to have this feature a bit more snappy, hence this PR.

The one thing I'm not sure about is the name of the variable used to configure this setting. I just stuck with the prefix that was already used in another one. I also saw that #6 did the same thing.

Maybe consider prefixing it with `cursorline_` instead to make it match the name of the plugin ?