### PR TITLE
fix: nil or empty highlight color

### DIFF
--- a/lua/nvim-cursorline.lua
+++ b/lua/nvim-cursorline.lua
@@ -18,7 +18,12 @@ o.cursorline = true
 
 local function return_highlight_term(group, term)
   local output = api.nvim_exec("highlight " .. group, true)
-  return fn.matchstr(output, term .. [[=\zs\S*]])
+  local hi = fn.matchstr(output, term .. [[=\zs\S*]])
+  if hi == nil or hi == '' then
+    return 'None'
+  else
+    return hi
+  end
 end
 
 local normal_bg = return_highlight_term("Normal", "guibg")


### PR DESCRIPTION
highlight guibg unset may cause:

```
E5108: Error executing lua .../pack/packer/opt/nvim-cursorline/lua/nvim-cursorline.lua:66: Vim(highlight):E417: missing argument: guibg=
```