### PR TITLE
Disable on filetype/buftype

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,1 @@
+globals = {"vim"}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nvim-cursorline
 
-Highlight words and lines on the cursor for Neovim 
+Highlight words and lines on the cursor for Neovim
 
 - Underlines the word under the cursor.
 - Show / hide cursorline in connection with cursor moving.
@@ -14,6 +14,10 @@ Install with your favorite plugin manager.
 You can override cursor highlighting by defining `CursorWord` group and disabling built-in highlighting by specifying `vim.g.cursorword_highlight` (lua) or `g:cursorword_highlight` (vimscript).
 
 To lower the time it takes to make the cursorline appear, set `vim.g.cursorline_timeout` (lua) or `g:cursorline_timeout` (vimscript), where `1000` is the default value in milliseconds.
+
+To disable the cursorline set `vim.g.cursorline_highlight` (lua) `g:cursorline_highlight` (vimscript) to `false`.
+
+To disable the cursorline or cursorword on certain filetypes or buffers set `vim.g.cursorline_disabled_filetypes`, `vim.g.cursorline_disabled_buftypes`, `vim.g.cursorword_diesabled_filetypes`, `vim.g.cursorword_diesabled_buftypes` (lua) `g:cursorline_disabled_filetypes`, `g:cursorline_disabled_buftypes`, `g: cursorword_diesabled_filetypes`, `g:cursorword_diesabled_buftypes` (vimscript) as tables (for multiple filetypes/buftypes) or strings (for single filetype/buftype).
 
 ## Acknowledgments
 Thanks goes to these people/projects for inspiration:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ To lower the time it takes to make the cursorline appear, set `vim.g.cursorline_
 
 To disable the cursorline set `vim.g.cursorline_highlight` (lua) `g:cursorline_highlight` (vimscript) to `false`.
 
-To disable the cursorline or cursorword on certain filetypes or buffers set `vim.g.cursorline_disabled_filetypes`, `vim.g.cursorline_disabled_buftypes`, `vim.g.cursorword_diesabled_filetypes`, `vim.g.cursorword_diesabled_buftypes` (lua) `g:cursorline_disabled_filetypes`, `g:cursorline_disabled_buftypes`, `g: cursorword_diesabled_filetypes`, `g:cursorword_diesabled_buftypes` (vimscript) as tables (for multiple filetypes/buftypes) or strings (for single filetype/buftype).
+To disable the cursorline or cursorword on certain filetypes or buffers set `vim.g.cursorline_disabled_filetypes`, `vim.g.cursorline_disabled_buftypes`, `vim.g.cursorword_disabled_filetypes`, `vim.g.cursorword_diesabled_buftypes` (lua) `g:cursorline_disabled_filetypes`, `g:cursorline_disabled_buftypes`, `g: cursorword_disabled_filetypes`, `g:cursorword_diesabled_buftypes` (vimscript) as tables (for multiple filetypes/buftypes) or strings (for single filetype/buftype).
+In example, setting `vim.g.cursorline_disabled_filetypes = {"NvimTree"}` (lua) `let g:cursorline_disabled_filetypes = ["NvimTree"]` (vimscript) disables the cursorline for the [nvim-tree](https://github.com/kyazdani42/nvim-tree.lua).
 
 ## Acknowledgments
 Thanks goes to these people/projects for inspiration:

--- a/lua/nvim-cursorline.lua
+++ b/lua/nvim-cursorline.lua
@@ -14,7 +14,9 @@ local api = vim.api
 
 local cursorline_timeout = g.cursorline_timeout and g.cursorline_timeout or 1000
 
-o.cursorline = true
+if g.cursorline_highlight ~= false then
+  o.cursorline = true
+end
 
 local function return_highlight_term(group, term)
   local output = api.nvim_exec("highlight " .. group, true)
@@ -28,6 +30,33 @@ end
 
 local normal_bg = return_highlight_term("Normal", "guibg")
 local cursorline_bg = return_highlight_term("CursorLine", "guibg")
+
+local function make_disabled_type_table(initial)
+  if type(initial) == "nil" then
+    return {}
+  elseif type(initial) == "string" then
+    return { initial }
+  elseif type(initial) == "table" then
+    return initial
+  end
+
+  return {}
+end
+
+local cursorword_disabled_filetypes = make_disabled_type_table(g.cursorword_disabled_filetypes)
+local cursorword_disabled_buffertypes = make_disabled_type_table(g.cursorword_disabled_buffertypes)
+local cursorline_disabled_filetypes = make_disabled_type_table(g.cursorline_disabled_filetypes)
+local cursorline_disabled_buffertypes = make_disabled_type_table(g.cursorline_disabled_buffertypes)
+
+local function should_disable_cursorword_on_buffer()
+  return table.contains(cursorword_disabled_filetypes, vim.bo.filetype)
+    or table.contains(cursorword_disabled_filetypes, vim.bo.filetype)
+end
+
+local function should_disable_cursorline_on_buffer()
+  return table.contains(cursorline_disabled_filetypes, vim.bo.filetype)
+    or table.contains(cursorline_disabled_filetypes, vim.bo.filetype)
+end
 
 function M.highlight_cursorword()
   if g.cursorword_highlight ~= false then
@@ -66,12 +95,14 @@ function M.cursor_moved()
     status = CURSOR
     return
   end
-  M.timer_start()
-  if status == CURSOR and cursorline_timeout ~= 0 then
-    -- disable cursorline
-    vim.cmd("highlight! CursorLine guibg=" .. normal_bg)
-    vim.cmd("highlight! CursorLineNr guibg=" .. normal_bg)
-    status = DISABLED
+  if g.cursorline_highlight ~= false then
+    M.timer_start()
+    if status == CURSOR and cursorline_timeout ~= 0 then
+      -- disable cursorline
+      vim.cmd("highlight! CursorLine guibg=" .. normal_bg)
+      vim.cmd("highlight! CursorLineNr guibg=" .. normal_bg)
+      status = DISABLED
+    end
   end
 end
 

--- a/plugin/nvim-cursorline.vim
+++ b/plugin/nvim-cursorline.vim
@@ -3,13 +3,15 @@ if exists('g:loaded_cursorword') || v:version < 703
 endif
 let g:loaded_cursorword = 1
 
-let s:save_cpo = &cpo
-set cpo&vim
+let s:save_cpoptions = &cpoptions
+set cpoptions&vim
 
-autocmd VimEnter * call luaeval("require'nvim-cursorline'.highlight_cursorword()")
-autocmd CursorMoved,CursorMovedI * call luaeval("require'nvim-cursorline'.cursor_moved()")
-autocmd WinEnter * call luaeval("require'nvim-cursorline'.win_enter()")
-autocmd WinLeave * call luaeval("require'nvim-cursorline'.win_leave()")
+augroup cursorline
+  autocmd! VimEnter * call luaeval("require'nvim-cursorline'.vim_enter()")
+  autocmd! CursorMoved,CursorMovedI * call luaeval("require'nvim-cursorline'.cursor_moved()")
+  autocmd! BufEnter * call luaeval("require'nvim-cursorline'.buf_enter()")
+  autocmd! BufLeave * call luaeval("require'nvim-cursorline'.buf_leave()")
+augroup END
 
-let &cpo = s:save_cpo
-unlet s:save_cpo
+let &cpoptions = s:save_cpoptions
+unlet s:save_cpoptions

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,2 @@
+indent_type = "Spaces"
+indent_width = 2


### PR DESCRIPTION
Fixes #10.

Moved everything to `BufEnter` and `BufLeave` events for this which are called after `WinEnter` and `WinLeave`, so the `matchadd` should work fine. Tested on my machine and it seems to be working.

Added minimal `stylua` and `luacheck` files, so my formatter and linter don't complain - I hope that's not an issue.

I'll add another commit for documentation in a couple of minutes.