### PR TITLE
feat: disable_filetypes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ require('nvim-cursorline').setup {
     enable = true,
     timeout = 1000,
     number = false,
+    disable_filetypes = {
+      'neo-tree'
+    },
   },
   cursorword = {
     enable = true,

--- a/lua/nvim-cursorline.lua
+++ b/lua/nvim-cursorline.lua
@@ -73,7 +73,6 @@ function M.setup(options)
     au({ "CursorMoved", "CursorMovedI" }, {
       callback = function()
         if disabled_filetype_lookup[vim.bo.filetype] then
-          vim.wo.cursorline = true
           return
         end
         if M.options.cursorline.number then
@@ -93,6 +92,13 @@ function M.setup(options)
           end)
         )
       end,
+    })
+    au("BufEnter", {
+      callback = function()
+        if disabled_filetype_lookup[vim.bo.filetype] then
+          wo.cursorline = true
+        end
+      end
     })
   end
 

--- a/lua/nvim-cursorline.lua
+++ b/lua/nvim-cursorline.lua
@@ -6,6 +6,7 @@ local wo = vim.wo
 local fn = vim.fn
 local hl = a.nvim_set_hl
 local au = a.nvim_create_autocmd
+local ag = a.nvim_create_augroup
 local timer = vim.loop.new_timer()
 
 local DEFAULT_OPTIONS = {
@@ -58,19 +59,23 @@ function M.setup(options)
     disabled_filetype_lookup[ft] = true
   end
 
+  local group_id = ag('nvim-cursorline', { clear = true })
   if M.options.cursorline.enable then
     wo.cursorline = true
     au("WinEnter", {
+      group = group_id,
       callback = function()
         wo.cursorline = true
       end,
     })
     au("WinLeave", {
+      group = group_id,
       callback = function()
         wo.cursorline = false
       end,
     })
     au({ "CursorMoved", "CursorMovedI" }, {
+      group = group_id,
       callback = function()
         if disabled_filetype_lookup[vim.bo.filetype] then
           return
@@ -94,9 +99,11 @@ function M.setup(options)
       end,
     })
     au("BufEnter", {
+      group = group_id,
       callback = function()
         if disabled_filetype_lookup[vim.bo.filetype] then
           wo.cursorline = true
+          wo.cursorlineopt = "both"
         end
       end
     })
@@ -104,12 +111,14 @@ function M.setup(options)
 
   if M.options.cursorword.enable then
     au("VimEnter", {
+      group = group_id,
       callback = function()
         hl(0, "CursorWord", M.options.cursorword.hl)
         matchadd()
       end,
     })
     au({ "CursorMoved", "CursorMovedI" }, {
+      group = group_id,
       callback = function()
         matchadd()
       end,

--- a/lua/nvim-cursorline.lua
+++ b/lua/nvim-cursorline.lua
@@ -13,6 +13,9 @@ local DEFAULT_OPTIONS = {
     enable = true,
     timeout = 1000,
     number = false,
+    disable_filetypes = {
+      'neo-tree'
+    },
   },
   cursorword = {
     enable = true,
@@ -50,6 +53,11 @@ end
 function M.setup(options)
   M.options = vim.tbl_deep_extend("force", DEFAULT_OPTIONS, options or {})
 
+  local disabled_filetype_lookup = {}
+  for _, ft in ipairs(M.options.cursorline.disable_filetypes) do
+    disabled_filetype_lookup[ft] = true
+  end
+
   if M.options.cursorline.enable then
     wo.cursorline = true
     au("WinEnter", {
@@ -64,6 +72,10 @@ function M.setup(options)
     })
     au({ "CursorMoved", "CursorMovedI" }, {
       callback = function()
+        if disabled_filetype_lookup[vim.bo.filetype] then
+          vim.wo.cursorline = true
+          return
+        end
         if M.options.cursorline.number then
           wo.cursorline = false
         else


### PR DESCRIPTION
## What I did
- add `disable_filetypes: string[]` option
- in `CursorMoved`, skip the rest of the cursorline logic if the filetype matches a disabled one
- re-enable cursorline when entering a filetype listed in `disable_filetypes`
- add a clearing autocmd group

Replaces #10 