### PR TITLE
fix: #25 Fixes vim:E976 error when cursor is on a blob.

### DIFF
--- a/lua/nvim-cursorline.lua
+++ b/lua/nvim-cursorline.lua
@@ -24,6 +24,9 @@ local DEFAULT_OPTIONS = {
 local function matchadd()
   local column = a.nvim_win_get_cursor(0)[2]
   local line = a.nvim_get_current_line()
+  if fn.type(line) == vim.v.t_blob then
+    return
+  end
   local cursorword = fn.matchstr(line:sub(1, column + 1), [[\k*$]])
     .. fn.matchstr(line:sub(column + 1), [[^\k*]]):sub(2)
 


### PR DESCRIPTION

- How to reproduce the original error:
#25
Open any binary file, move cursor on a blob(blue characters starting with ^), throws vim:E976.
This error is thrown when blob is provided for function `vim.fn.matchstr()`, instead of a string.
- What changes I've made:
  - In function `matchadd()` (line 12),
  - Check whether the current line is a blob, seeing if `fn.type(line)` is a `vim.v.t_blob`.
  - If it is a blob, return early from matchadd()
- Test results:
I tried reproducing the bug as I mentioned above, and it was fixed.
Testing environment: MacOS Ventura 13.1, Apple M2, nvim v0.8.3