### PR TITLE
Bugfix: Unsafe check on cursorword_id

### DIFF
--- a/lua/nvim-cursorline.lua
+++ b/lua/nvim-cursorline.lua
@@ -31,8 +31,8 @@ local function matchadd()
     return
   end
   w.cursorword = cursorword
-  if w.cursorword_id then
-    vim.call("matchdelete", w.cursorword_id)
+  _, ok = pcall(vim.call, "matchdelete", w.cursorword_id)
+  if not ok then
     w.cursorword_id = nil
   end
   if


### PR DESCRIPTION
## Issue
If ":call clearmatches()" was performed, it would break the cursorword highlighting for that window

## Discovery
I discovered this bug while installing and testing out ThePrimeagen's latest harpoon update. When opening the harpoon menu, the clearmatches() function was called. This would cause an error message to pop up anytime the cursor moved in the popup menu. Closing the popup menu would fix it in the open file however.

I believe this is a bug in this plugin as there is a check on the existence of `cursorword_id` on the `w` object, but that does not take into account whether that that id actually gets deleted.


## How to reproduce (discovery)

1. minimal init.lua: [https://pastebin.com/DUp8H0Yx](https://pastebin.com/DUp8H0Yx)  
2. open a file with some text greater than 3 characters
3. move cursor over to that word
4. open quick menu with <space>mm
5. error!

## How to reproduce (general case)

1. open a file with some text greater than 3 characters
2. move cursor over to that word
3. do ":call clearmatches()"
4. error!

## Fix
Move deletion into a `pcall` function and retain previous code flow with the `if` check.

_p.s. I am new to open source development. If there's anything i can fix about my post, please let me know. I would really appreciate it_