### PR TITLE
Show more of available options for highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ https://user-images.githubusercontent.com/42740055/163586272-17560f83-9195-4cb4-
 
 Install with your favorite plugin manager.
 
-## Usage
+## Default settings
 
 ```lua
 require('nvim-cursorline').setup {
@@ -30,6 +30,39 @@ require('nvim-cursorline').setup {
   }
 }
 ```
+
+## Options for block highlighting
+
+```lua
+require('nvim-cursorline').setup {
+  cursorline = {
+    enable = false,
+  },
+  cursorword = {
+    enable = true,
+    min_length = 1,
+    hl = {
+      underline = false,
+      fg = "#c0caf5",
+      bg = "#565f89",
+      sp = nil,
+      blend = 0,
+      bold = false,
+      standout = false,
+      underline = false,
+      undercurl = false,
+      underdouble = false,
+      underdotted = false,
+      underdashed = false,
+      strikethrough = false,
+      italic = false,
+      reverse = false,
+      nocombine = false,
+    },
+  }
+}
+```
+Most of the cursorword options are shown above. See a complete list of properties that can be set for `val` in the Neovim documentation: https://neovim.io/doc/user/api.html#nvim_set_hl().
 
 ## Acknowledgments
 


### PR DESCRIPTION
Hi @yamatsum, 

I really like your plugin. It's simple and hasn't caused performance problems that I've come across with other cursorword plugins. It took me a while to realize it offered highlighting as well as underlining when I looked at the implementation and the docs for vim.api.nvim_set_hl. I thought there might be some value to other potential users by adding another example showing highlighting and the other options available.