### PR TITLE
Fix bug that occurs when opening help documents

### DIFF
--- a/lua/nvim-cursorline.lua
+++ b/lua/nvim-cursorline.lua
@@ -43,7 +43,7 @@ local function matchadd()
   then
     return
   end
-  local pattern = [[\<]] .. vim.fn.escape(cursorword, "~") .. [[\>]]
+  local pattern = [[\<]] .. vim.fn.escape(cursorword, "~[]") .. [[\>]]
   w.cursorword_id = fn.matchadd("CursorWord", pattern, -1)
 end
 

--- a/lua/nvim-cursorline.lua
+++ b/lua/nvim-cursorline.lua
@@ -43,7 +43,7 @@ local function matchadd()
   then
     return
   end
-  local pattern = [[\<]] .. cursorword .. [[\>]]
+  local pattern = [[\<]] .. vim.fn.escape(cursorword, "~") .. [[\>]]
   w.cursorword_id = fn.matchadd("CursorWord", pattern, -1)
 end
 


### PR DESCRIPTION
Escape tildes when calling `fn.matchadd("CursorWord", pattern, -1)` so that it doesn't throw the error `Vim:E874: (NFA) Could not pop the stack!` when scrolling through help documents like the following (`:h cmp_docs`):
```md
Config                                                              *cmp-config*

You can use the following options via `cmp.setup { ... }` .

                                                            *cmp-config.enabled*
enabled~ <-- TILDE HERE CAUSES ERROR
  `boolean | fun(): boolean`
  Toggles the plugin on and off.
```