### PR TITLE
Fix cursorword not working with lazy.nvim

### DIFF
--- a/lua/nvim-cursorline.lua
+++ b/lua/nvim-cursorline.lua
@@ -85,12 +85,7 @@ function M.setup(options)
   end
 
   if M.options.cursorword.enable then
-    au("VimEnter", {
-      callback = function()
-        hl(0, "CursorWord", M.options.cursorword.hl)
-        matchadd()
-      end,
-    })
+    hl(0, "CursorWord", M.options.cursorword.hl)
     au({ "CursorMoved", "CursorMovedI" }, {
       callback = function()
         matchadd()


### PR DESCRIPTION
I'm using neovim v0.10 and lazy.nvim to load plugins, with following configurations for nvim-cursorline.

```sh
  {
    "luftaquila/nvim-cursorline",
    event = "VimEnter",
    config = function()
      require("nvim-cursorline").setup {}
    end,
  },
```

Since highlighting `hl(0, "CursorWord", M.options.cursorword.hl)` is called on `VimEnter` event, I think it is hard to work with lazy.nvim. None of vim or lazy.nvim events I tried worked with cursorword when lazy loading this plugin.

I think it is better to set highlights during setup, not on `VimEnter`. Please check and apply if you like it. Thank you for a great plugin!